### PR TITLE
Faling test

### DIFF
--- a/test/es6.test.js
+++ b/test/es6.test.js
@@ -65,3 +65,10 @@ describe('is<className> method', () => {
         expect(Plant.isPlant(mammal)).toBe(false);
     });
 });
+
+describe('it satisfies deep.equal', () => {
+    it('should satisfy deep equality with duck typed object', () => {
+        expect(new Animal.WrappedClass('cat')).toEqual({ type: 'cat' });
+        expect(new Animal('cat')).toEqual({ type: 'cat' });
+    });
+});


### PR DESCRIPTION
As per @achingbrain https://github.com/ipld/js-ipld-dag-pb/pull/184#discussion_r436880297 chai's `deep.equal` check instance created via `class-is` should match it's duck-typed counterpart. It appears that `[Symbol.toStringTag]` field prevents that from happening. This pull request adds failing test that illustrates the issue.